### PR TITLE
Collect Fluentbit logs

### DIFF
--- a/pravega-k8-log-collection/README.md
+++ b/pravega-k8-log-collection/README.md
@@ -1,28 +1,59 @@
-# pravega-k8-log-collection
-Pravega K8 based deployment log collection tool
+# Pravega Log Collection Utilities for Kubernetes
+
+We present the available log collection scripts for Pravega deployed on a Kubernetes cluster.
+
+## Collect logs from Pravega services
 
 The shell script (`pravega-k8s-log.sh`) which will do below stuff:
-1. list all pod, services and persistent volumes running in the K8 deployment
-2. Check all Pravega components associated
-3. If component is a pod it will collect log from that container:
-	 It will collect recent logs
-	 It will check whether container had been restarted due to any reason and would take logs from previous deployment as well (if any).
-	 It will take complete logs (including logrotated so far) from Pravega Segmentstore and Controller (e.g. /opt/pravega/logs)  
-4. Take details of all pod, service and pvcs (describe output)
-5. Create a tarball with time stamp in present working directory under `pravega-k8s-logs`
+1. List all pods, services and persistent volumes running in the K8 deployment.
+2. Check all Pravega components associated.
+3. If component is a pod it will collect log from that container: i) It will collect recent logs.
+ii) It will check whether container had been restarted due to any reason and would take logs from previous deployment as well (if any).
+iii) It will take complete logs (including logrotated so far) from Pravega Segmentstore and Controller (e.g. `/opt/pravega/logs`).
 
-Sample Usage:
+4. Take details of all pod, service and pvcs (describe output).
+5. Create a tarball with time stamp in present working directory under `pravega-k8s-logs`.
+
+Sample usage:
 
 `# chmod +x pravega-k8s-log.sh`
 
 `# ./pravega-k8s-log.sh`
 
-Logs collected in $PWD/pravega-k8s-logs
+Logs collected in `$PWD/pravega-k8s-logs`
 
 Sample log output:
-/home/work/pravega-k8-log-collection/pravega-k8s-logs/pravega-k8s-logging-2018-12-05-07-06-26.tgz
+
+`/home/work/pravega-k8-log-collection/pravega-k8s-logs/pravega-k8s-logging-2018-12-05-07-06-26.tgz`
 
 Note:
 1. Script assumes valid kubernetes configuration present in the node where it is invoked.
 2. `kubectl` should be present in the system.
-3. Doesn't handle logs from `evicted` pods and collect only describe output for those.
+3. Does not handle logs from `evicted` pods and collect only describe output for those.
+
+## Collect logs from Fluentbit service
+
+The shell script (`pravega-k8s-fluentbit-log.sh`) does the following:
+1. List all pods, services and persistent volumes running in the K8 deployment.
+2. Check all Fluentbit pods in the current deployment.
+3. For each Fluentbit pod: i) Creates a temporary `tar.gz` file with all the logs. 
+ii) Downloads the compressed log file and tries to structure the folders in a meaningful way for developers inspecting the logs.
+4. Take details of all pod, service and pvcs (describe output).
+5. Create a tarball with time stamp in present working directory under `pravega-k8s-logs`.
+
+Sample usage:
+
+`# chmod +x pravega-k8s-fluentbit-log.sh`
+
+`# ./pravega-k8s-fluentbit-log.sh`
+
+Logs collected in `$PWD/pravega-k8s-logs`
+
+Sample log output:
+
+`/home/work/pravega-k8-log-collection/pravega-k8s-logs/pravega-k8s-logging-2019-03-01-08-15-36.tgz`
+
+Note:
+1. Script assumes valid kubernetes configuration present in the node where it is invoked.
+2. `kubectl` should be present in the system.
+3. Script assumes that there is a Fluentbit service storing data locally (local storage or remote volume) via the syslog output plugin.

--- a/pravega-k8-log-collection/pravega-k8s-fluentbit-log.sh
+++ b/pravega-k8-log-collection/pravega-k8s-fluentbit-log.sh
@@ -33,7 +33,7 @@ do
             # Create a tar.gz file with all the logs contained in the fluentbit pod.
             exitcode=0
             kubectl -n $namespace exec $fluentbit_pod -- bash -c "tar -czf /tmp/$fluentbit_pod.tar.gz /var/vcap/store/docker/docker/containers" || exitcode=$?
-            # Some logs may be being written during collection, which makes tar to exit with a non-zero code. Need to handle this case.
+            # Some logs may be being written during collection, which makes tar to exit with exit code 1. Need to handle this case.
             if [ "$exitcode" != "1" ] && [ "$exitcode" != "0" ]; then
                     exit $exitcode
             fi

--- a/pravega-k8-log-collection/pravega-k8s-fluentbit-log.sh
+++ b/pravega-k8-log-collection/pravega-k8s-fluentbit-log.sh
@@ -12,8 +12,8 @@
 #
 set -euo pipefail
 # Setting up temporary log collection directory under /tmp/logdir
-mkdir -p ./logdir
 output_dir="./logdir"
+mkdir -p $output_dir
 # Capturing pod, services and persistentvolumeclaim information from all namespaces
 kubectl get po,svc,pvc --all-namespaces > $output_dir/kubectl-get-po-svc-pvc-all-namespace_output
 IFS=$'\n'
@@ -21,60 +21,56 @@ IFS=$'\n'
 for i in $(cat $output_dir/kubectl-get-po-svc-pvc-all-namespace_output | grep -i fluent-bit)
 do
 
-# Detect Pravega pods information in various K8 deployment (e.g. PKS / GKE)
-if [[ $i == *"po/"* ]] || [[ $i == *"pod/"* ]]; then
+    # Detect Pravega pods information in various K8 deployment (e.g. PKS / GKE)
+    if [[ $i == *"po/"* ]] || [[ $i == *"pod/"* ]]; then
 
-    # Collect logs from "Running" pods, if pods are not in "Running" state it will collect describe information.
-    if [ "`echo $i | awk '{print $4}'`" == "Running" ]; then
-    {
         fluentbit_pod=$(echo $i |  awk '-F'[/] '{print $2}'| awk '{print $1}')
-        namespace=$(echo $i | awk '{print $1}')
-        # Clean any pre-existing tar file in the fluentbit pod.
-        kubectl -n $namespace exec $fluentbit_pod -- bash -c "rm /tmp/$fluentbit_pod.tar.gz" || true
-        # Create a tar.gz file with all the logs contained in the fluentbit pod.
-        set +e
-        kubectl -n $namespace exec $fluentbit_pod -- bash -c "tar -czf /tmp/$fluentbit_pod.tar.gz /var/vcap/store/docker/docker/containers"
-        exitcode=$?
-        # Some logs may be being written during collection, which makes tar to exit with a non-zero code. Need to handle this case.
-        if [ "$exitcode" != "1" ] && [ "$exitcode" != "0" ]; then
-                exit $exitcode
-        fi
-        set -e
-        # Download the compressed file from the fluentbit pod.
-        kubectl cp $namespace/$fluentbit_pod:/tmp/$fluentbit_pod.tar.gz $output_dir
-        # Remove temporal compressed file from fluentbit pod.
-        kubectl -n $namespace exec $fluentbit_pod -- bash -c "rm /tmp/$fluentbit_pod.tar.gz"
-        # Untar the contents to provide a better structure of the resulting logs artifact.
-        tar -xzvf $output_dir/$fluentbit_pod.tar.gz -C $output_dir
-        mv $output_dir/var/vcap/store/docker/docker/containers/ $output_dir/$fluentbit_pod
-        # Delete useless files from downloaded fluentbit dirs (preserve only .log files and the directory structure).
-        for container_dir in $(find $output_dir/$fluentbit_pod -maxdepth 1 -mindepth 1 -type d)
-        do
-                echo $container_dir
-                mv $container_dir/*.log $container_dir/..
-                rm -rf $container_dir/*
-                mv $container_dir/../*.log $container_dir
-        done
-        # Relate the name of the pods being logged with the actual log data.
-        kubectl -n $namespace exec $fluentbit_pod -- ls /var/vcap/store/docker/docker/containers/ > $output_dir/container-lognames
-        kubectl -n $namespace exec $fluentbit_pod -- ls /var/log/containers/ > $output_dir/pod-lognames
-        for podlog in $(cat $output_dir/pod-lognames)
-        do
-                log_pod_name=$(echo $podlog | awk -F_ '{print $1}')
-                log_container_name=$(echo $podlog | awk -F- '{print $NF}' |  awk -F. '{print $1}')
-                # This will help to easily locate the logs by pod name, but also appended the container prefix (5 chars)
-                # to avoid overwriting logs from restarted pods.
-                mv $output_dir/$fluentbit_pod/$log_container_name  $output_dir/$fluentbit_pod/$log_pod_name'-'$(echo $log_container_name | awk '{print substr($0,0,5)}') || true
+        # Collect logs from "Running" pods, if pods are not in "Running" state it will collect describe information.
+        if [ "`echo $i | awk '{print $4}'`" == "Running" ]; then
+            namespace=$(echo $i | awk '{print $1}')
+            # Clean any pre-existing tar file in the fluentbit pod.
+            kubectl -n $namespace exec $fluentbit_pod -- bash -c "rm /tmp/$fluentbit_pod.tar.gz" || true
+            # Create a tar.gz file with all the logs contained in the fluentbit pod.
+            exitcode=0
+            kubectl -n $namespace exec $fluentbit_pod -- bash -c "tar -czf /tmp/$fluentbit_pod.tar.gz /var/vcap/store/docker/docker/containers" || exitcode=$?
+            # Some logs may be being written during collection, which makes tar to exit with a non-zero code. Need to handle this case.
+            if [ "$exitcode" != "1" ] && [ "$exitcode" != "0" ]; then
+                    exit $exitcode
+            fi
+            # Download the compressed file from the fluentbit pod.
+            kubectl cp $namespace/$fluentbit_pod:/tmp/$fluentbit_pod.tar.gz $output_dir
+            # Remove temporal compressed file from fluentbit pod.
+            kubectl -n $namespace exec $fluentbit_pod -- bash -c "rm /tmp/$fluentbit_pod.tar.gz"
+            # Untar the contents to provide a better structure of the resulting logs artifact.
+            tar -xzf $output_dir/$fluentbit_pod.tar.gz -C $output_dir
+            mv $output_dir/var/vcap/store/docker/docker/containers/ $output_dir/$fluentbit_pod
+            # Delete useless files from downloaded fluentbit dirs (preserve only .log files and the directory structure).
+            for container_dir in $(find $output_dir/$fluentbit_pod -maxdepth 1 -mindepth 1 -type d)
+            do
+                    echo $container_dir
+                    mv $container_dir/*.log $container_dir/..
+                    rm -rf $container_dir/*
+                    mv $container_dir/../*.log $container_dir
+            done
+            # Relate the name of the pods being logged with the actual log data.
+            kubectl -n $namespace exec $fluentbit_pod -- ls /var/vcap/store/docker/docker/containers/ > $output_dir/container-lognames
+            kubectl -n $namespace exec $fluentbit_pod -- ls /var/log/containers/ > $output_dir/pod-lognames
+            for podlog in $(cat $output_dir/pod-lognames)
+            do
+                    log_pod_name=$(echo $podlog | awk -F_ '{print $1}')
+                    log_container_name=$(echo $podlog | awk -F- '{print $NF}' |  awk -F. '{print $1}')
+                    # This will help to easily locate the logs by pod name, but also appended the container prefix (5 chars)
+                    # to avoid overwriting logs from restarted pods.
+                    mv $output_dir/$fluentbit_pod/$log_container_name  $output_dir/$fluentbit_pod/$log_pod_name'-'$(echo $log_container_name | awk '{print substr($0,0,5)}') || true
 
-        done
-        # Clean temporal files.
-        rm -rf $output_dir/$fluentbit_pod.tar.gz
-        rm -rf $output_dir/var
-    }
-    else
-       echo $fluentbit_pod" is not in running state"
+            done
+            # Clean temporal files.
+            rm -rf $output_dir/$fluentbit_pod.tar.gz
+            rm -rf $output_dir/var
+        else
+           echo $fluentbit_pod" is not in running state"
+        fi
     fi
-fi
 done
 
 for i in $(cat $output_dir/kubectl-get-po-svc-pvc-all-namespace_output)
@@ -92,3 +88,4 @@ cd $output_dir
 tar zcf $cwd/pravega-k8s-logs/pravega-k8s-logging-`date '+%Y-%m-%d-%H-%M-%S'`.tgz *
 rm -rf ../$output_dir
 echo "Final logs are available in `ls $cwd/pravega-k8s-logs/*.tgz`"
+exit 0

--- a/pravega-k8-log-collection/pravega-k8s-fluentbit-log.sh
+++ b/pravega-k8-log-collection/pravega-k8s-fluentbit-log.sh
@@ -44,7 +44,7 @@ if [[ $i == *"po/"* ]] || [[ $i == *"pod/"* ]]; then
         kubectl -n $namespace exec $podname -- bash -c "rm /tmp/$podname.tar.gz"
         # Untar the contents to provide a better structure of the resulting logs artifact.
         tar -xzvf $output_dir/$podname.tar.gz -C $output_dir
-        mv $output_dir/var/vcap/store/docker/docker/containers/ $output_dir/containers
+        mv $output_dir/var/vcap/store/docker/docker/containers/ $output_dir/$podname
         # Relate the name of the pods being logged with the actual log data.
         kubectl -n $namespace exec $podname -- ls /var/vcap/store/docker/docker/containers/ > $output_dir/container-lognames
         kubectl -n $namespace exec $podname -- ls /var/log/containers/ > $output_dir/pod-lognames
@@ -53,7 +53,7 @@ if [[ $i == *"po/"* ]] || [[ $i == *"pod/"* ]]; then
                 log_pod_name=$(echo $podlog | awk -F_ '{print $1}')
                 log_container_name=$(echo $podlog | awk -F- '{print $NF}' |  awk -F. '{print $1}')
                 # This will help to easily locate the logs by pod name.
-                mv $output_dir/containers/$log_container_name  $output_dir/containers/$log_pod_name
+                mv $output_dir/$podname/$log_container_name  $output_dir/$podname/$log_pod_name
 
         done
         # Clean temporal files.

--- a/pravega-k8-log-collection/pravega-k8s-fluentbit-log.sh
+++ b/pravega-k8-log-collection/pravega-k8s-fluentbit-log.sh
@@ -62,8 +62,9 @@ if [[ $i == *"po/"* ]] || [[ $i == *"pod/"* ]]; then
         do
                 log_pod_name=$(echo $podlog | awk -F_ '{print $1}')
                 log_container_name=$(echo $podlog | awk -F- '{print $NF}' |  awk -F. '{print $1}')
-                # This will help to easily locate the logs by pod name.
-                mv $output_dir/$fluentbit_pod/$log_container_name  $output_dir/$fluentbit_pod/$log_pod_name || true
+                # This will help to easily locate the logs by pod name, but also appended the container prefix (5 chars)
+                # to avoid overwriting logs from restarted pods.
+                mv $output_dir/$fluentbit_pod/$log_container_name  $output_dir/$fluentbit_pod/$log_pod_name'-'$(echo $log_container_name | awk '{print substr($0,0,5)}') || true
 
         done
         # Clean temporal files.

--- a/pravega-k8-log-collection/pravega-k8s-fluentbit-log.sh
+++ b/pravega-k8-log-collection/pravega-k8s-fluentbit-log.sh
@@ -53,7 +53,7 @@ if [[ $i == *"po/"* ]] || [[ $i == *"pod/"* ]]; then
                 log_pod_name=$(echo $podlog | awk -F_ '{print $1}')
                 log_container_name=$(echo $podlog | awk -F- '{print $NF}' |  awk -F. '{print $1}')
                 # This will help to easily locate the logs by pod name.
-                mv $output_dir/$fluentbit_pod/$log_container_name  $output_dir/$fluentbit_pod/$log_pod_name
+                mv $output_dir/$fluentbit_pod/$log_container_name  $output_dir/$fluentbit_pod/$log_pod_name || true
 
         done
         # Clean temporal files.

--- a/pravega-k8-log-collection/pravega-k8s-fluentbit-log.sh
+++ b/pravega-k8-log-collection/pravega-k8s-fluentbit-log.sh
@@ -1,0 +1,83 @@
+#/usr/bin/env bash
+#
+# Pravega K8 based log collection tool
+#
+# Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+set -euo pipefail
+# Setting up temporary log collection directory under /tmp/logdir
+mkdir -p ./logdir
+output_dir="./logdir"
+# Capturing pod, services and persistentvolumeclaim information from all namespaces
+kubectl get po,svc,pvc --all-namespaces > $output_dir/kubectl-get-po-svc-pvc-all-namespace_output
+IFS=$'\n'
+# We now rok only on the "fluentbit" pods that contain the logs of the rest of services.
+for i in $(cat $output_dir/kubectl-get-po-svc-pvc-all-namespace_output | grep -i fluent-bit)
+do
+
+# Detect Pravega pods information in various K8 deployment (e.g. PKS / GKE)
+if [[ $i == *"po/"* ]] || [[ $i == *"pod/"* ]]; then
+
+    # Collect logs from "Running" pods, if pods are not in "Running" state it will collect describe information.
+    if [ "`echo $i | awk '{print $4}'`" == "Running" ]; then
+    {
+        podname=$(echo $i |  awk '-F'[/] '{print $2}'| awk '{print $1}')
+        namespace=$(echo $i | awk '{print $1}')
+        # Create a tar.gz file with all the logs contained in the fluentbit pod.
+        set +e
+        kubectl -n $namespace exec $podname -- bash -c "tar -czf /tmp/$podname.tar.gz /var/vcap/store/docker/docker/containers"
+        exitcode=$?
+        # Some logs may be being written during collection, which makes tar to exit with a non-zero code. Need to handle this case.
+        if [ "$exitcode" != "1" ] && [ "$exitcode" != "0" ]; then
+                exit $exitcode
+        fi
+        set -e
+        # Download the compressed file from the fluentbit pod.
+        kubectl cp $namespace/$podname:/tmp/$podname.tar.gz $output_dir
+        # Remove temporal compressed file from fluentbit pod.
+        kubectl -n $namespace exec $podname -- bash -c "rm /tmp/$podname.tar.gz"
+        # Untar the contents to provide a better structure of the resulting logs artifact.
+        tar -xzvf $output_dir/$podname.tar.gz -C $output_dir
+        mv $output_dir/var/vcap/store/docker/docker/containers/ $output_dir/containers
+        # Relate the name of the pods being logged with the actual log data.
+        kubectl -n $namespace exec $podname -- ls /var/vcap/store/docker/docker/containers/ > $output_dir/container-lognames
+        kubectl -n $namespace exec $podname -- ls /var/log/containers/ > $output_dir/pod-lognames
+        for podlog in $(cat $output_dir/pod-lognames)
+        do
+                log_pod_name=$(echo $podlog | awk -F_ '{print $1}')
+                log_container_name=$(echo $podlog | awk -F- '{print $NF}' |  awk -F. '{print $1}')
+                # This will help to easily locate the logs by pod name.
+                mv $output_dir/containers/$log_container_name  $output_dir/containers/$log_pod_name
+
+        done
+        # Clean temporal files.
+        rm -rf $output_dir/$podname.tar.gz
+        rm -rf $output_dir/var
+    }
+    else
+       echo $podname" is not in running state"
+    fi
+fi
+done
+
+for i in $(cat $output_dir/kubectl-get-po-svc-pvc-all-namespace_output)
+do
+if [ "`echo $i | awk '{print $1}'`" != "NAMESPACE" ]; then
+    # Collect details of resources information (pod, services, persistentvolumeclaim) for all resource phases (e.g. "Running", "Evicted")
+    kubectl -n `echo $i | awk '{print $1}'` describe `echo $i | awk '{print $2}'` > $output_dir/describe_`echo $i | awk 'gsub(/\//,"_") {print $2}'`_output
+fi
+done
+
+cwd=`pwd`
+mkdir -p $cwd/pravega-k8s-logs
+cd $output_dir
+# Create compressed log archive with date stamp
+tar zcf $cwd/pravega-k8s-logs/pravega-k8s-logging-`date '+%Y-%m-%d-%H-%M-%S'`.tgz *
+rm -rf ../$output_dir
+echo "Final logs are available in `ls $cwd/pravega-k8s-logs/*.tgz`"


### PR DESCRIPTION
**Change log description**
Added a new log collecting script for fluentbit service (using syslog output plugin).

**Purpose of the change**
Fixes #8 and #9.

**What the code does**
This PR adds a new script for collecting logs from a Kubernetes cluster containing a `fluentbit` service. This script is useful in scenarios where `fluentbit` stores logs from cluster pods locally (either in local storage or in a mounted volume) in the form of log files. The script does the following work:
1) It loops though the existing `fluentbit` pods and creates a temporary `tar.gz` file on each pod with all the logs.
2) It download these compressed log files from all the `fluentbit` pods and tries to structure the folders in a meaningful way for developers inspecting the logs.
3) As in the existing script `pravega-k8s-log.sh`, the new one also `describe`s all the pods, pvcs, and services in the cluster.
4) It cleans up temporary files both locally and in `fluentbit` pods.

The `README` has been updated as well.

**How to verify it**
Collected logs from 2 clusters successfully. One of these clusters contained 4 `fluentbit` pods.
