### PR TITLE
Issue 28: Remove "readonly" Bookie from cluster get-instances command

### DIFF
--- a/pravega-cli/src/main/java/io/pravega/tools/pravegacli/commands/utils/ZKHelper.java
+++ b/pravega-cli/src/main/java/io/pravega/tools/pravegacli/commands/utils/ZKHelper.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
@@ -77,7 +79,8 @@ public class ZKHelper implements AutoCloseable {
      * @return A list of bookies.
      */
     public List<String> getBookies() {
-        return getChild(BK_PATH);
+        List<String> bookies = getChild(BK_PATH);
+        return bookies != null ? bookies.stream().filter(s -> s.contains(":")).collect(Collectors.toList()) : null;
     }
 
     /**


### PR DESCRIPTION
**Change log description**
Remove "readonly" artifact when listing Bookies registered in Zookeeper.

**Purpose of the change**
Fixes #28.

**What the code does**
Upon retrieving the Bookies registered in Zookeeper, this PR adds a filter to remove everything that does not contain `:`, which is an expected separator character for Bookie address (i.e., `IP:PORT`).

**How to verify it**
The command `cluster get-instances` should not retrieve `readonly` in the list of Bookies:
```
> cluster list-instances
Cluster name: pravega
Controller instances in the cluster:
> xxxx:9090:58554735-e755-44b5-bab5-d897a99f7d4c
Segment Store instances in the cluster:
> xxxx:12345:
Bookies in the cluster:
> xxxx:3181
> xxxx:3181
> xxxx:3181
```

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>