### PR TITLE
Issue 55: Resource-based provisioning model

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,7 @@ Pravega clusters.
 We provide two scripts: one that collects the logs from the pods themselves, and another one that assumes the
 existence of a logging service (i.e., FluentBit) to collect the logs from.
 
+- Pravega provisioning helper: Script tool that help with the right-sizing and proper configuration of a Pravega
+cluster.
+
 For detailed documentation of each tool, we refer to their respective README files.

--- a/pravega-provisioner/cluster_provisioner.py
+++ b/pravega-provisioner/cluster_provisioner.py
@@ -140,7 +140,7 @@ def resource_based_provisioning(vms, vm_cpus, vm_ram_gb, zookeeper_servers, book
     max_segment_stores_per_vm = math.ceil(vms / segment_stores)
     new_direct_memory = Constants.segment_store_direct_memory_in_gb + int(min_vm_mem_available/max_segment_stores_per_vm)
     print("--------- Segment Store In-Memory Cache Size (Pravega +0.7) ---------")
-    print("Segment Store pod memory limit: ", Constants.segment_store_jvm_size_in_gb, "GB")
+    print("Segment Store pod memory limit: ", Constants.segment_store_jvm_size_in_gb + new_direct_memory, "GB")
     print("Segment Store JVM Size (-Xmx JVM Option) : ", Constants.segment_store_jvm_size_in_gb, "GB")
     print("Segment Store direct memory (-DirectMemory JVM Option): ", new_direct_memory, "GB")
     # We leave 1GB extra of direct memory for non-caching purposes

--- a/pravega-provisioner/cluster_provisioner.py
+++ b/pravega-provisioner/cluster_provisioner.py
@@ -168,8 +168,7 @@ def resource_based_provisioning(vms, vm_cpus, vm_ram_gb, vm_local_drives, zookee
     # aware placement in Bookkeeper so it tries to write to Bookies in different nodes (data availability).
     if bookkeeper_servers > vms:
         print("WARNING: To guarantee data availability and durability, consider enabling rack-aware placement in "
-              "Pravega to write to Bookkeeper. Otherwise, Segment Stores may be writing to Bookies on the same node,"
-              "which make the system more vulnerable to node failures.")
+              "Pravega to write to Bookkeeper.")
 
     return zookeeper_servers, bookkeeper_servers, segment_stores, controllers
 

--- a/pravega-provisioner/cluster_provisioner.py
+++ b/pravega-provisioner/cluster_provisioner.py
@@ -90,7 +90,7 @@ def resource_based_provisioning(vms, vm_cpus, vm_ram_gb, vm_local_drives, zookee
         assert False, "You have not enough nodes to tolerate such amount of failures"
     elif vms - failures_to_tolerate < Constants.min_bookkeeper_servers or vms - failures_to_tolerate < Constants.min_zookeeper_servers:
         # If we are collocating more than 1 Zookeeper or Bookie per node, we need an additional instance. Otherwise, we
-        # lead in a situation like the following: 3 VM/nodes with 4 Bookie/Zookeeper servers. This means that there is
+        # lead into a situation like the following: 3 VM/nodes with 4 Bookie/Zookeeper servers. This means that there is
         # one node with 2 instances, and if this node crashes, then we fall below the min number of replicas defined.
         zookeeper_servers += 1
         bookkeeper_servers += 1
@@ -108,7 +108,8 @@ def resource_based_provisioning(vms, vm_cpus, vm_ram_gb, vm_local_drives, zookee
     can_allocate_cluster, the_cluster = can_allocate_services_on_nodes(vms, vm_cpus, vm_ram_gb, vm_local_drives,
                                                     zookeeper_servers, bookkeeper_servers, segment_stores, controllers)
     # First, make sure that whatever initial number of instances can be allocated, otherwise just throw an error.
-    assert can_allocate_cluster, "Not even the minimal Pravega cluster can be allocated with the current resources"
+    assert can_allocate_cluster, "Not even the minimal Pravega cluster can be allocated with the current resources. " + \
+                                 "Please, check the Constants file to see the resources requested per instance."
 
     # Ask to the user whether this is a metadata-intensive workload or not.
     metadata_heavy_workload = get_bool_input("Is the workload metadata-heavy (i.e., many clients, small transactions)?")

--- a/pravega-provisioner/model/constants.py
+++ b/pravega-provisioner/model/constants.py
@@ -36,6 +36,13 @@ class Constants:
     segment_store_jvm_size_in_gb = 4
     segment_store_direct_memory_in_gb = segment_store_ram_gb - segment_store_jvm_size_in_gb
 
+    # Number of local drives per Bookie:
+    #   i)   1 drive means that Journal, Ledger and Index are located on the same drive.
+    #   ii)  2 drives means that Journal is on one drive, whereas Ledger and Index are on the same drive.
+    #   iii) 3 drives means that Journal, Ledger and Index are on independent disks.
+    # By default, we assume that at least each Bookie has 2 drives to separate Journal from Ledger/Index IOs.
+    drives_per_bookie = 2
+
 
     @staticmethod
     def zookeeper_to_bookies_ratio(bookies):

--- a/pravega-provisioner/model/constants.py
+++ b/pravega-provisioner/model/constants.py
@@ -6,9 +6,10 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
+import math
 
 
-class Constants(object):
+class Constants:
     """
     Constant values and assumptions for the Pravega cluster provisioning model.
     """
@@ -22,13 +23,56 @@ class Constants(object):
     # Recommended resources to be provisioned per Pravega cluster instance.
     zk_server_ram_gb = 2
     zk_server_cpus = 1
-    bookie_ram_gb = 4
-    bookie_cpus = 2
-    controller_ram_gb = 3
+    bookie_ram_gb = 16
+    bookie_cpus = 8
+    controller_ram_gb = 4
     controller_cpus = 2
-    segment_store_ram_gb = 6
-    segment_store_cpus = 4
+    segment_store_ram_gb = 16
+    segment_store_cpus = 8
 
     # Number of segment containers and buckets per Segment Store and Controller, respectively.
     segment_containers_per_segment_store = 8
     stream_buckets_per_controller = 4
+
+
+    @staticmethod
+    def zookeeper_to_bookies_ratio(bookies):
+        """
+        Number of Zookeeper instances based on the number of Bookies in the system, as Bookkeeper is the service that
+        makes a more intensive use of Zookeeper managing metadata (more than the Controller). For large deployments
+        e.g., > 20 Bookies), we keep a ratio of Zookeeper servers to Bookies of 1:4.
+        """
+        zk_instances = math.ceil(bookies / 4)
+        if zk_instances < Constants.min_zookeeper_servers:
+            return Constants.min_zookeeper_servers
+        elif zk_instances / 2 == 0:
+            # We should keep an odd number of Zookeeper servers.
+            return zk_instances + 1
+        else:
+            return zk_instances
+
+
+    @staticmethod
+    def segment_stores_to_bookies_ratio(bookies):
+        """
+        In our benchmarks, we observe that we require the one Segment Store per Bookie to get full saturation of fast
+        drives. Therefore, we define a 1:1 ratio between Bookies and Segment Stores.
+        """
+        return bookies
+
+
+    @staticmethod
+    def controllers_to_segment_stores_ratio(segment_stores, metadata_heavy_workload):
+        """
+        Unless the workload at hand is very metadata intensive (i.e., many clients, very small transactions), we can
+        keep a 1:3 ratio between Controllers and Segment Stores. Otherwise, we can switch to a 1:2 ratio
+        """
+        ratio = 3
+        if metadata_heavy_workload:
+            ratio = 2
+        controllers = segment_stores / ratio
+        if controllers < Constants.min_controllers:
+            return Constants.min_controllers
+        else:
+            return math.ceil(controllers)
+

--- a/pravega-provisioner/model/constants.py
+++ b/pravega-provisioner/model/constants.py
@@ -47,7 +47,7 @@ class Constants:
         zk_instances = math.ceil(bookies / 4)
         if zk_instances < Constants.min_zookeeper_servers:
             return Constants.min_zookeeper_servers
-        elif zk_instances / 2 == 0:
+        elif zk_instances % 2 == 0:
             # We should keep an odd number of Zookeeper servers.
             return zk_instances + 1
         else:

--- a/pravega-provisioner/model/constants.py
+++ b/pravega-provisioner/model/constants.py
@@ -33,6 +33,8 @@ class Constants:
     # Number of segment containers and buckets per Segment Store and Controller, respectively.
     segment_containers_per_segment_store = 8
     stream_buckets_per_controller = 4
+    segment_store_jvm_size_in_gb = 4
+    segment_store_direct_memory_in_gb = segment_store_ram_gb - segment_store_jvm_size_in_gb
 
 
     @staticmethod

--- a/pravega-provisioner/model/provisioning_logic.py
+++ b/pravega-provisioner/model/provisioning_logic.py
@@ -176,10 +176,9 @@ def can_allocate_services_on_nodes(vms, vm_cpus, vm_ram_gb, zookeeper_servers, b
     return True, the_cluster
 
 
-def _subtract_resources_from_cluster(the_cluster, num_instances, cpu_per_instance, ram_per_instance):
+def _subtract_resources_from_cluster(the_cluster, num_instances, cpu_per_instance, ram_per_instance, enforce_load_balancing=True):
     finish_allocation = False
     completed_allocations = retries = 0
-    perfect_instance_distribution_across_nodes = True
     while not finish_allocation:
         for x in range(num_instances - completed_allocations):
             [old_cpu, old_ram] = the_cluster[x % len(the_cluster)]
@@ -192,15 +191,9 @@ def _subtract_resources_from_cluster(the_cluster, num_instances, cpu_per_instanc
 
         if num_instances == completed_allocations:
             finish_allocation = True
-        if retries > 0:
-            perfect_instance_distribution_across_nodes = False
-        if retries >= len(the_cluster):
+        if retries > 0 and enforce_load_balancing or retries >= len(the_cluster):
             return False
         retries += 1
-
-    if not perfect_instance_distribution_across_nodes:
-        print("WARNING: It is not possible to perfectly distribute instances across nodes, which will impact on the"
-              " failure tolerance of the cluster.")
 
     return True
 

--- a/pravega-provisioner/model/provisioning_logic.py
+++ b/pravega-provisioner/model/provisioning_logic.py
@@ -152,39 +152,43 @@ def calc_controllers_for_workload(num_streams, heavy_operations_per_second, ligh
                light_operations_per_second / performance_profile.controller_max_light_operations_per_second + 1))
 
 
-def can_allocate_services_on_nodes(vms, vm_cpus, vm_ram_gb, zookeeper_servers, bookkeeper_servers, segment_stores, controllers):
+def can_allocate_services_on_nodes(vms, vm_cpus, vm_ram_gb, vm_local_drives, zookeeper_servers, bookkeeper_servers, segment_stores, controllers):
     the_cluster = list()
     # Initialize the cluster modelling the resources available (VM_CPUS, VM_RAM).
     for i in range(vms):
-        the_cluster.append((vm_cpus, vm_ram_gb))
+        the_cluster.append((vm_cpus, vm_ram_gb, vm_local_drives, []))
 
     # Allocate the different instances in a round robin fashion across nodes to maximize failure tolerance.
     # Start allocating Bookies
-    if not _subtract_resources_from_cluster(the_cluster, bookkeeper_servers, Constants.bookie_cpus, Constants.bookie_ram_gb):
+    drives_per_bookie = 0
+    if vm_local_drives > 0:
+        drives_per_bookie = Constants.drives_per_bookie
+    if not _subtract_resources_from_cluster(the_cluster, bookkeeper_servers, Constants.bookie_cpus, Constants.bookie_ram_gb, drives_per_bookie, "bk"):
         return False, the_cluster
     # Then, attempt to allocate Segment Stores
-    if not _subtract_resources_from_cluster(the_cluster, segment_stores, Constants.segment_store_cpus, Constants.segment_store_ram_gb):
+    if not _subtract_resources_from_cluster(the_cluster, segment_stores, Constants.segment_store_cpus, Constants.segment_store_ram_gb, 0, "ss"):
         return False, the_cluster
     # Attempt to allocate Controllers
-    if not _subtract_resources_from_cluster(the_cluster, controllers, Constants.controller_cpus, Constants.controller_ram_gb):
+    if not _subtract_resources_from_cluster(the_cluster, controllers, Constants.controller_cpus, Constants.controller_ram_gb, 0, "c"):
         return False, the_cluster
     # Attempt to allocate Zookeeper servers
-    if not _subtract_resources_from_cluster(the_cluster, zookeeper_servers, Constants.zk_server_cpus, Constants.zk_server_ram_gb):
+    if not _subtract_resources_from_cluster(the_cluster, zookeeper_servers, Constants.zk_server_cpus, Constants.zk_server_ram_gb, 0, "zk"):
         return False, the_cluster
 
     # Allocation of all the instances has been possible.
     return True, the_cluster
 
 
-def _subtract_resources_from_cluster(the_cluster, num_instances, cpu_per_instance, ram_per_instance, enforce_load_balancing=True):
+def _subtract_resources_from_cluster(the_cluster, num_instances, cpu_per_instance, ram_per_instance, drives_per_instance, node_type, enforce_load_balancing=True):
     finish_allocation = False
     completed_allocations = retries = 0
     while not finish_allocation:
         for x in range(num_instances - completed_allocations):
-            [old_cpu, old_ram] = the_cluster[x % len(the_cluster)]
+            [old_cpu, old_ram, old_drives, processes_in_vm] = the_cluster[x % len(the_cluster)]
             # Only allocate when there are enough resources
-            if (old_cpu - cpu_per_instance) >= 0 and (old_ram - ram_per_instance) >= 0:
-                the_cluster[x % len(the_cluster)] = (old_cpu - cpu_per_instance, old_ram - ram_per_instance)
+            if (old_cpu - cpu_per_instance) >= 0 and (old_ram - ram_per_instance) >= 0 and (old_drives - drives_per_instance) >= 0:
+                processes_in_vm.append(node_type)
+                the_cluster[x % len(the_cluster)] = (old_cpu - cpu_per_instance, old_ram - ram_per_instance, old_drives - drives_per_instance, processes_in_vm)
                 completed_allocations += 1
         # After allocating instances, sort nodes based on available resources.
         the_cluster.sort(key=lambda tup: tup[0], reverse=True)

--- a/pravega-provisioner/model/provisioning_logic.py
+++ b/pravega-provisioner/model/provisioning_logic.py
@@ -151,3 +151,57 @@ def calc_controllers_for_workload(num_streams, heavy_operations_per_second, ligh
                heavy_operations_per_second / performance_profile.controller_max_heavy_operations_per_second + 1,
                light_operations_per_second / performance_profile.controller_max_light_operations_per_second + 1))
 
+
+def can_allocate_services_on_nodes(vms, vm_cpus, vm_ram_gb, zookeeper_servers, bookkeeper_servers, segment_stores, controllers):
+    the_cluster = list()
+    # Initialize the cluster modelling the resources available (VM_CPUS, VM_RAM).
+    for i in range(vms):
+        the_cluster.append((vm_cpus, vm_ram_gb))
+
+    # Allocate the different instances in a round robin fashion across nodes to maximize failure tolerance.
+    # Start allocating Bookies
+    if not _subtract_resources_from_cluster(the_cluster, bookkeeper_servers, Constants.bookie_cpus, Constants.bookie_ram_gb):
+        return False, the_cluster
+    # Then, attempt to allocate Segment Stores
+    if not _subtract_resources_from_cluster(the_cluster, segment_stores, Constants.segment_store_cpus, Constants.segment_store_ram_gb):
+        return False, the_cluster
+    # Attempt to allocate Controllers
+    if not _subtract_resources_from_cluster(the_cluster, controllers, Constants.controller_cpus, Constants.controller_ram_gb):
+        return False, the_cluster
+    # Attempt to allocate Zookeeper servers
+    if not _subtract_resources_from_cluster(the_cluster, zookeeper_servers, Constants.zk_server_cpus, Constants.zk_server_ram_gb):
+        return False, the_cluster
+
+    # Allocation of all the instances has been possible.
+    return True, the_cluster
+
+
+def _subtract_resources_from_cluster(the_cluster, num_instances, cpu_per_instance, ram_per_instance):
+    finish_allocation = False
+    completed_allocations = retries = 0
+    perfect_instance_distribution_across_nodes = True
+    while not finish_allocation:
+        for x in range(num_instances - completed_allocations):
+            [old_cpu, old_ram] = the_cluster[x % len(the_cluster)]
+            # Only allocate when there are enough resources
+            if (old_cpu - cpu_per_instance) >= 0 and (old_ram - ram_per_instance) >= 0:
+                the_cluster[x % len(the_cluster)] = (old_cpu - cpu_per_instance, old_ram - ram_per_instance)
+                completed_allocations += 1
+        # After allocating instances, sort nodes based on available resources.
+        the_cluster.sort(key=lambda tup: tup[0], reverse=True)
+
+        if num_instances == completed_allocations:
+            finish_allocation = True
+        if retries > 0:
+            perfect_instance_distribution_across_nodes = False
+        if retries >= len(the_cluster):
+            return False
+        retries += 1
+
+    if not perfect_instance_distribution_across_nodes:
+        print("WARNING: It is not possible to perfectly distribute instances across nodes, which will impact on the"
+              " failure tolerance of the cluster.")
+
+    return True
+
+


### PR DESCRIPTION
**Change log description**
Add a resource-based provisioning model for Pravega cluster.

**Purpose of the change**
Fixes #52. 

**What the code does**
This PR adds a new provisioning model for Pravega clusters. The objective is, given a set of nodes with CPU and memory resources, suggest to the user a proper Pravega cluster configuration (instance number, resource-related parameters) to exploit most of the cluster resources. In summary, the model follows the following steps:
1) It asks for the number of nodes/vms, and the CPU and RAM of each one.
2) The model defines some resource required for the different instance types, as well as the ratio of instances across services (i.e., 1 Bookie per 1 Segment Store to achieve saturation, 1 or 2 controllers for every 3 Segment Stores, depending on the metadata requirements expected, etc.).
3) The model tries to allocate an increasing number of instances of each type (respecting the aforementioned ratios) in a "round robin" fashion (mocking the anti-affinity policies we apply on pods to maximize availability) until either CPU or RAM of the cluster is exhausted.
4) If there is extra memory left in all the nodes, then we calculate how much memory can be contributed to the cache of the Segment Store instances.
5) The model outputs the information about the cluster size for each instance type, as well as some configuration parameters to be introduced in the configuration file to deploy the cluster.

**How to verify it**
Executed several scenarios and it seems to work as expected. We still need to review some design decisions of the model and apply in on a real cluster.