### PR TITLE
Issue 63: Improve pravega-provisioner tool to use it from other scripts

### DIFF
--- a/pravega-provisioner/model/constants.py
+++ b/pravega-provisioner/model/constants.py
@@ -13,6 +13,7 @@ class Constants:
     """
     Constant values and assumptions for the Pravega cluster provisioning model.
     """
+    VERBOSE_OUTPUT = True
     # Minimum Pravega Cluster deployment to preserve data durability (3-way replication). Nothing less than this should
     # be considered for non-testing deployments.
     min_zookeeper_servers = 3

--- a/pravega-provisioner/model/provisioning_logic.py
+++ b/pravega-provisioner/model/provisioning_logic.py
@@ -183,7 +183,7 @@ def _subtract_resources_from_cluster(the_cluster, num_instances, cpu_per_instanc
     finish_allocation = False
     completed_allocations = retries = 0
     while not finish_allocation:
-        for x in range(num_instances - completed_allocations):
+        for x in range(int(num_instances) - completed_allocations):
             [old_cpu, old_ram, old_drives, processes_in_vm] = the_cluster[x % len(the_cluster)]
             # Only allocate when there are enough resources
             if (old_cpu - cpu_per_instance) >= 0 and (old_ram - ram_per_instance) >= 0 and (old_drives - drives_per_instance) >= 0:


### PR DESCRIPTION
### Purpose of the change
Fixes #63

### What the code does
1. This PR aims to parameterize input to resource_based_provisioning, so that calling script can gather required input from end user in customized way and pass it to the model.
2. Returns output as python object (a dictionary) with well known keys.
3. Prints messages to screen based on verbose setting.
4. Fixes input methods to retry instead of bailing out.
5. Fixes python import errors.

### How it is verified

Ran the script directly and also called from another python program.

1) Direct invocation
```
python3 ./pravega-provisioner/cluster_provisioner.py
### Provisioning model for Pravega clusters ###
Please, introduce the resource information about the VMs used int cluster:
How many CPU cores has each VM/node?72
How much memory in GB has each VM/node?384
Is your cluster using local drives? (yes, no)6
Is your cluster using local drives? (yes, no)yes
How many local drives has each VM/node?6
Do you want to provision a Pravega cluster based on 0) the resources available, 1) the input workload, 2) none?(valid values: [0, 1, 2])0
How many VMs/nodes do you want to devote for a Pravega cluster?4
How many node failures you want to tolerate?(valid values: range(0, 100))0
Is the workload metadata-heavy (i.e., many clients, small transactions)? (yes, no)no
Allocation of pods on nodes:  [(22, 284, 0, ['bk', 'bk', 'bk', 'ss', 'ss', 'ss', 'c']), (21, 282, 0, ['bk', 'bk', 'bk', 'ss', 'ss', 'ss', 'c', 'zk']), (21, 282, 0, ['bk', 'bk', 'bk', 'ss', 'ss', 'ss', 'c', 'zk']), (21, 282, 0, ['bk', 'bk', 'bk', 'ss', 'ss', 'ss', 'c', 'zk'])]
--------- Segment Store In-Memory Cache Size (Pravega +0.7) ---------
Segment Store pod memory limit:  110 GB
Segment Store JVM Size (-Xmx JVM Option) :  4 GB
Segment Store direct memory (-DirectMemory JVM Option):  106 GB
Segment Store cache size (pravegaservice.cacheMaxSize):  112742891520  ( 105 GB)
Buffering time that Pravega tolerates with Tier 2 unavailable given a (well distributed) write workload:
- Write throughput:  100 (MBps) -> buffering time:  12902.4  seconds
- Write throughput:  300 (MBps) -> buffering time:  4300.8  seconds
- Write throughput:  500 (MBps) -> buffering time:  2580.48  seconds
- Write throughput:  700 (MBps) -> buffering time:  1843.2  seconds
- Write throughput:  900 (MBps) -> buffering time:  1433.6  seconds
WARNING: To guarantee data availability and durability, consider enabling rack-aware placement in Pravega to write to Bookkeeper.
--------- Cluster Provisioning ---------
Number of VMs required:  4
Number of Zookeeper servers required:  3
Number of Bookkeeper servers required:  12
Number of Segment Stores servers required:  12
Number of Controller servers required:  4
--------- Cluster Config Params ---------
Number of Segment Containers in config:  96
Number of Stream Buckets in config:  16
```

2)  calling it from another python program (nautilus-dist/scripts/provisioner.py)
https://eos2git.cec.lab.emc.com/NAUT/nautilus-dist/pull/294

NOTE: --num-cpu entered below is physical cores, inside provisioner.py it is multiplied by 2 (vCPU:pCPU ration assumed to be 2:1)
```
 python3 ./provisioner.py --outfile provisioner_output.txt \
     --num-hosts-present 4 \
     --num-hosts-added 2 \
     --num-host-failures 0 \
     --num-cpu 36 \
     --mem 384 \
     --local-disk-count 6 \
     --is-bk-on-bosh True \ 
     --percent-analytics 50 

Gathering input required to scaling the cluster:

Percent of resources for Analytics 50
Percent of resources for Pravega 40
Resources for pravega per each new ESXi host: vCPU: 24, memory: 160 GB
--------- Segment Store In-Memory Cache Size (Pravega +0.7) ---------
Segment Store pod memory limit:  128 GB
Segment Store JVM Size (-Xmx JVM Option) :  4 GB
Segment Store direct memory (-DirectMemory JVM Option):  124 GB
Segment Store cache size (pravegaservice.cacheMaxSize):  132070244352  ( 123 GB)
Buffering time that Pravega tolerates with Tier 2 unavailable given a (well distributed) write workload:
- Write throughput:  100 (MBps) -> buffering time:  2519.04  seconds
- Write throughput:  300 (MBps) -> buffering time:  839.68  seconds
- Write throughput:  500 (MBps) -> buffering time:  503.81  seconds
- Write throughput:  700 (MBps) -> buffering time:  359.86  seconds
- Write throughput:  900 (MBps) -> buffering time:  279.89  seconds
WARNING: To guarantee data availability and durability, consider enabling rack-aware placement in Pravega to write to Bookkeeper.
--------- Segment Store In-Memory Cache Size (Pravega +0.7) ---------
Segment Store pod memory limit:  32 GB
Segment Store JVM Size (-Xmx JVM Option) :  4 GB
Segment Store direct memory (-DirectMemory JVM Option):  28 GB
Segment Store cache size (pravegaservice.cacheMaxSize):  28991029248  ( 27 GB)
Buffering time that Pravega tolerates with Tier 2 unavailable given a (well distributed) write workload:
- Write throughput:  100 (MBps) -> buffering time:  1935.36  seconds
- Write throughput:  300 (MBps) -> buffering time:  645.12  seconds
- Write throughput:  500 (MBps) -> buffering time:  387.07  seconds
- Write throughput:  700 (MBps) -> buffering time:  276.48  seconds
- Write throughput:  900 (MBps) -> buffering time:  215.04  seconds

Suggested additional worker VM count for pravega: 10
Suggested additional pravega replicas:
  zk instaces: 3
  bk instances on Bosh: 3
  segment stores: 7
  controllers: 3
```         
