### PR TITLE
Issue 78: Deprecate Pravega CLI in Pravega Tools repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ charge of the correct operation, deployment and troubleshooting of a Pravega clu
 
 At the moment, this repository provides the following tools:
 
-- Pravega CLI (administration): Command Line Interface for administrators to inspect, troubleshoot and repair
-Pravega clusters.
+- Pravega CLI (_deprecated in this repository_): Command Line Interface for administrators to inspect, troubleshoot and repair
+Pravega clusters. **DEPRECATION WARNING**: _The Pravega CLI has been migrated to the Pravega core repo and this
+codebase is stale and will be eventually removed. To use Pravega CLI, please refer to https://github.com/pravega/pravega_. 
 
 - Pravega log collection scripts: Set of scripts to easily collect logs from all instances in a Pravega cluster.
 We provide two scripts: one that collects the logs from the pods themselves, and another one that assumes the

--- a/pravega-cli/README.md
+++ b/pravega-cli/README.md
@@ -7,9 +7,11 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 -->
-# Pravega CLI
+# Pravega CLI (DEPRECATED IN THIS REPOSITORY)
 
-Pravega CLI is a tool for inspecting and exploring Pravega deployments.
+Pravega CLI is a tool for inspecting and exploring Pravega deployments. 
+**DEPRECATION WARNING**: _The Pravega CLI has been migrated to the Pravega core repo and this
+codebase is stale and will be eventually removed. To use Pravega CLI, please refer to https://github.com/pravega/pravega_. 
 
 ## Prerequisites
 


### PR DESCRIPTION
**Change log description**
Added deprecation warning in Pravega CLI documentation.

**Purpose of the change**
Fixes #78.

**What the code does**
Adds deprecation warnings related to Pravega CLI module.

**How to verify it**
No change in code.

Signed-off-by: Raúl <raul.gracia@emc.com>