### PR TITLE
Issue 80: Collect k8s logs from all containers

### DIFF
--- a/pravega-k8-log-collection/pravega-k8s-fluentbit-log.sh
+++ b/pravega-k8-log-collection/pravega-k8s-fluentbit-log.sh
@@ -1,4 +1,4 @@
-#/usr/bin/env bash
+#!/usr/bin/env bash
 #
 # Pravega K8 based log collection tool
 #

--- a/pravega-k8-log-collection/pravega-k8s-log.sh
+++ b/pravega-k8-log-collection/pravega-k8s-log.sh
@@ -1,4 +1,4 @@
-#/usr/bin/env bash
+#!/usr/bin/env bash
 #
 # Pravega K8 based log collection tool
 #
@@ -31,7 +31,7 @@ if [[ $i == *"po/"* ]] || [[ $i == *"pod/"* ]]; then
             kubectl -n `echo $i | awk '{print $1}'` logs `echo $i | awk '{print $2}'` -p > $output_dir/log_`echo $i | awk 'gsub(/\//,"_") {print $2}'`_previous.log
         fi
 # Collect recent logs from pod
-        kubectl -n `echo $i | awk '{print $1}'` logs `echo $i | awk '{print $2}'` > $output_dir/log_`echo $i | awk 'gsub(/\//,"_") {print $2}'`_recent.log
+        kubectl -n `echo $i | awk '{print $1}'` logs `echo $i | awk '{print $2}'` --all-containers > $output_dir/log_`echo $i | awk 'gsub(/\//,"_") {print $2}'`_recent.log
 # Detect if the pod have older logs due to logroate and collect all logs from that pod
         log_count=$(kubectl -n `echo $i | awk '{print $1}'` exec -it `echo $i |  awk '-F'[/] '{print $2}'|awk '{print $1}'` -- ls -l /opt/pravega/logs 2>/dev/null | wc -l || true)
         if [ $log_count -ge 2 ]; then  


### PR DESCRIPTION
**Change log description**
Collect k8s logs from all containers

**Purpose of the change**
Fixes https://github.com/pravega/pravega-tools/issues/80.

**What the code does**
Specify in `kubectl` command to collect logs from all containers

**How to verify it**
Ran the `pravega-k8s-log.sh` script and verified that logs from all containers ended up in the final log archive.

Signed-off-by: Tewit Srisomboon <tewit.srisomboon@emc.com>
